### PR TITLE
Fix the agent's error collector not being reset after forking

### DIFF
--- a/lib/new_relic/agent/agent.rb
+++ b/lib/new_relic/agent/agent.rb
@@ -525,6 +525,7 @@ module NewRelic
         # making sure the agent is in a fresh state
         def reset_stats
           @stats_engine.reset_stats
+          @error_collector.errors.clear
           @unsent_errors = []
           @traces = nil
           @unsent_timeslice_data = {}

--- a/test/new_relic/agent/agent_test.rb
+++ b/test/new_relic/agent/agent_test.rb
@@ -67,6 +67,20 @@ module NewRelic
         end
       end
 
+      def test_after_fork_should_reset_errors_collected
+        with_config(:monitor_mode => true) do
+          @agent.stubs(:connected?).returns(true)
+
+          errors = []
+          errors << NewRelic::NoticedError.new("", {}, Exception.new("boo"))
+          @agent.merge_data_from([{}, [], errors])
+
+          @agent.after_fork(:report_to_channel => 123)
+
+          assert_equal 0, @agent.error_collector.errors.length, "Still got errors collected in parent"
+        end
+      end
+
       def test_transmit_data_should_emit_before_harvest_event
         got_it = false
         @agent.events.subscribe(:before_harvest) { got_it = true }


### PR DESCRIPTION
In the `after_fork` hook, stats are supposed to be reset to be prevent the child process from reporting data collected by the parent.  While the `unsent_errors` get reset, the error collector does not -- which means if the parent process is reporting errors, there's a possibility that the children can report the same errors.  This updates `reset_stats` to also reset the errors that have been collected.

Since some of this isn't going to be in a NewRelic release necessarily anytime soon, I'm starting an integration branch on our fork.

/to @StabbyCutyou @akasper @ydderd
